### PR TITLE
Only lazy-load direct parameters and buffers

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -87,4 +87,5 @@ def evaluate(args, get_model, get_input, apply_optimization, warmup_repeat=10, r
 
     with open(path, 'w') as f:
         json.dump(result, f)
-    print(args.method, result)
+    print(args.method, f'{args.device}+{args.storage_device}', result)
+    print()

--- a/pylomin/data_porters/data_porter.py
+++ b/pylomin/data_porters/data_porter.py
@@ -18,3 +18,11 @@ class DataPorter:
     def get_save_path(self, module):
         return os.path.join(self.weight_dir,
                             f'{self.module2name[module]}.pt')
+
+    def get_direct_parameters(self, module):
+        # TODO: Don't access protected attribute (check if name contains dot?)
+        return module._parameters.items()
+
+    def get_direct_buffers(self, module):
+        # TODO: Don't access protected attribute (check if name contains dot?)
+        return module._buffers.items()

--- a/pylomin/data_porters/data_porter_disk.py
+++ b/pylomin/data_porters/data_porter_disk.py
@@ -14,8 +14,8 @@ class DataPorterDisk(DataPorter):
     def _save_weights(self, module):
         module = module.to(self.computing_device)
         torch.save({
-            'parameters': list(module.named_parameters()),
-            'buffers': list(module.named_buffers()),
+            'parameters': list(self.get_direct_parameters(module)),
+            'buffers': list(self.get_direct_buffers(module)),
         }, self.get_save_path(module))
 
     def release_weights(self, module, *_, first_time=False):
@@ -25,7 +25,9 @@ class DataPorterDisk(DataPorter):
         weight_names = [
             name
             for name, _ in chain(
-                module.named_parameters(), module.named_buffers())
+                self.get_direct_parameters(module),
+                self.get_direct_buffers(module)
+            )
         ]
         for name in weight_names:
             setattr(module, name, None)

--- a/pylomin/data_porters/data_porter_ram.py
+++ b/pylomin/data_porters/data_porter_ram.py
@@ -7,11 +7,17 @@ class DataPorterRAM(DataPorter):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def release_weights(self, module, *_, **kwargs):
-        module.to('cpu')
+    def _move_weights(self, module, device):
+        for _, param in self.get_direct_parameters(module):
+            param.data = param.to(device)
+        for _, buffer in self.get_direct_buffers(module):
+            buffer.data = buffer.to(device)
+
+    def release_weights(self, module, *_, **_kwargs):
+        self._move_weights(module, 'cpu')
 
     def load_weights(self, module, *_):
-        module.to(self.computing_device)
+        self._move_weights(module, self.computing_device)
 
 
 # TODO check Tensor.to(non_blocking=True)


### PR DESCRIPTION
The word "direct" means excluding the parameters and buffers of its `children()`.